### PR TITLE
Added a tip for forwarding jupiter notebook port running on a VM to host machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ export PYSPARK_DRIVER_PYTHON_OPTS="notebook --NotebookApp.open_browser=True --No
 ```
 will set up two environment variables for `pyspark` to execute `jupyter`.
 
-If you are running Vagrant or other virtualized environment and would like to forward jupiter notebook to a port on the host machine, set the NotebookApp.ip flag to `--NotebookApp.io='0.0.0.0'`
+If you are running Vagrant or other virtualized environment and would like to forward jupiter notebook to a port on the host machine, set the NotebookApp.ip flag to `--NotebookApp.ip='0.0.0.0'`
 
 The next line:
 ```bash

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ export PYSPARK_DRIVER_PYTHON_OPTS="notebook --NotebookApp.open_browser=True --No
 ```
 will set up two environment variables for `pyspark` to execute `jupyter`.
 
+If you are running Vagrant or other virtualized environment and would like to forward jupiter notebook to a port on the host machine, set the NotebookApp.ip flag to `--NotebookApp.io='0.0.0.0'`
+
 The next line:
 ```bash
 ${SPARK_HOME}/bin/pyspark \

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ export PYSPARK_DRIVER_PYTHON_OPTS="notebook --NotebookApp.open_browser=True --No
 ```
 will set up two environment variables for `pyspark` to execute `jupyter`.
 
-If you are running Vagrant or other virtualized environment and would like to forward jupiter notebook to a port on the host machine, set the NotebookApp.ip flag to `--NotebookApp.ip='0.0.0.0'`
+If you are running Vagrant or other virtualized environment and would like to forward jupiter notebook to a port on the host machine, set the NotebookApp.ip flag to `--NotebookApp.ip='0.0.0.0'`. You can then access jupiter notebook from the host machine on localhost:8888.
 
 The next line:
 ```bash


### PR DESCRIPTION
I was not able to connect to localhost:8888 in a browser on my host machine to jupiter notebook running on vagrant . It took me about 45 min to figure out why. Hopefully this tip will save someone else some time!